### PR TITLE
Fix wai request conversion

### DIFF
--- a/framework/mafia
+++ b/framework/mafia
@@ -120,4 +120,4 @@ case "$MODE" in
 upgrade) shift; run_upgrade "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: 8bcf922a5993d8d566a6682db5a493e90300da9a
+# Version: 7c6993f5ad2ac2a605cbc46cd5a108358b5e8c06

--- a/hadron-wai/ambiata-hadron-wai.cabal
+++ b/hadron-wai/ambiata-hadron-wai.cabal
@@ -62,4 +62,5 @@ test-suite test-io
                      , quickcheck-instances            == 0.3.*
                      , semigroups                      >= 0.16       && < 0.19
                      , text                            == 1.2.*
+                     , wai                             >= 3.0 && < 3.3
 

--- a/hadron-wai/src/Hadron/Wai/Request.hs
+++ b/hadron-wai/src/Hadron/Wai/Request.hs
@@ -61,7 +61,7 @@ toHTTPRequest_1_1 r = do
     goFetch fetch acc =
       fetch >>= \bs -> if BS.null bs
         then pure acc
-        else pure $ bs : acc
+        else goFetch fetch $ bs : acc
 
     parse' e p bs = case AB.parseOnly p bs of
       Left _ -> left $ e bs

--- a/hadron-wai/src/Hadron/Wai/Request.hs
+++ b/hadron-wai/src/Hadron/Wai/Request.hs
@@ -38,7 +38,9 @@ import           X.Control.Monad.Trans.Either (hoistEither, left)
 --
 -- Achtung: as hadron does not currently support streaming request bodies,
 -- this will read the entire payload into memory regardless of how it is
--- chunked inside wai.
+-- chunked inside wai. wai's requestBody, strictRequestBody and
+-- lazyRequestBody functions will return an empty result for the
+-- request after this.
 toHTTPRequest :: W.Request -> EitherT WaiRequestError IO HTTPRequest
 toHTTPRequest r = do
   case W.httpVersion r of

--- a/hadron-wai/src/Hadron/Wai/Request.hs
+++ b/hadron-wai/src/Hadron/Wai/Request.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BangPatterns #-}
 module Hadron.Wai.Request(
     toHTTPRequest
   , fromHTTPRequest
@@ -58,7 +59,7 @@ toHTTPRequest_1_1 r = do
     buildRequestBody fetch =
       fmap (RequestBody . BS.concat . reverse) $ goFetch fetch []
 
-    goFetch fetch acc =
+    goFetch fetch !acc =
       fetch >>= \bs -> if BS.null bs
         then pure acc
         else goFetch fetch $ bs : acc

--- a/hadron-wai/test/Test/IO/Hadron/Wai/Request.hs
+++ b/hadron-wai/test/Test/IO/Hadron/Wai/Request.hs
@@ -3,11 +3,19 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Test.IO.Hadron.Wai.Request where
 
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.IORef as I
+import           Data.List (replicate)
+
+import           Disorder.Core.Gen (utf8BS1)
 import           Disorder.Core.IO (testIO)
 import           Disorder.Core.Run (ExpectedTestSpeed(..), disorderCheckEnvAll)
 
 import           Hadron.Core
 import           Hadron.Wai.Request
+
+import qualified Network.Wai as W
 
 import           P
 
@@ -23,6 +31,27 @@ prop_tripping_HTTPRequest hr = testIO $ do
   wr <- fromHTTPRequest hr
   hr' <- runEitherT $ toHTTPRequest wr
   pure $ hr' === Right hr
+
+-- Make sure we convert wai requests with multi-chunk bodies correctly.
+prop_tripping_HTTPRequest_chunked :: HTTPRequest -> Property
+prop_tripping_HTTPRequest_chunked hr = forAll (choose (2, 20)) $ \n -> forAll utf8BS1 $ \bs -> testIO $ do
+  wr <- fromHTTPRequest hr
+  b <- chunkedBody n bs
+  let wr' = wr { W.requestBody = b }
+  let hr'' = hr `withBody` (RequestBody . BS.concat $ replicate n bs)
+  hr' <- runEitherT $ toHTTPRequest wr'
+  pure $ hr' === Right hr''
+
+withBody :: HTTPRequest -> RequestBody -> HTTPRequest
+withBody (HTTPV1_1Request r) b =
+  HTTPV1_1Request $ r { hrqv1_1Body = b }
+
+chunkedBody :: Int -> ByteString -> IO (IO ByteString)
+chunkedBody n bs = do
+  chunksRead <- I.newIORef 0
+  pure . I.atomicModifyIORef' chunksRead $ \cr -> case cr == n of
+    True -> (n, "")
+    False -> (cr + 1, bs)
 
 return []
 tests :: IO Bool

--- a/hadron-wai/test/Test/IO/Hadron/Wai/Request.hs
+++ b/hadron-wai/test/Test/IO/Hadron/Wai/Request.hs
@@ -19,8 +19,8 @@ import           Test.Hadron.Core.Arbitrary ()
 import           X.Control.Monad.Trans.Either (runEitherT)
 
 prop_tripping_HTTPRequest :: HTTPRequest -> Property
-prop_tripping_HTTPRequest hr = testIO $
-  let wr = fromHTTPRequest hr in do
+prop_tripping_HTTPRequest hr = testIO $ do
+  wr <- fromHTTPRequest hr
   hr' <- runEitherT $ toHTTPRequest wr
   pure $ hr' === Right hr
 


### PR DESCRIPTION
Two showstopper bugs here, hiding each other from the tests.

 - The function to recursively read the wai request body did not actually recurse, and only returned the first chunk (fortunately, enough for most HTTP requests).
 - The wai version of a hadron request had a `requestBody` which unconditionally yielded its one chunk, meaning that functions expecting a different chunk each time terminated by the empty ByteString recurse forever and try to allocate infinite memory.

I should definitely add some conversion tests with multi-chunk request bodies; I'll do that tomorrow, just want to get this fix in for now.

! @thumphries @erikd-ambiata 
 